### PR TITLE
Update demo to use .NET 6.0

### DIFF
--- a/src/PdfProcessingAzureFunc/PdfProcessingAzureFunc.csproj
+++ b/src/PdfProcessingAzureFunc/PdfProcessingAzureFunc.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AzureFunctionsVersion>v3</AzureFunctionsVersion>
   </PropertyGroup>
   <ItemGroup>

--- a/src/PdfProcessingAzureFunc/PdfProcessingAzureFunc.csproj
+++ b/src/PdfProcessingAzureFunc/PdfProcessingAzureFunc.csproj
@@ -10,7 +10,7 @@
     <!-- Add ".Trial" to the end of every Telerik package name if you are using a trial license.
      For example, Include="Telerik.Documents.Core.Trial" instead of Include="Telerik.Documents.Core" 
     -->
-    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="3.0.9" />
+    <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.0" />
     <PackageReference Include="Telerik.Documents.Core" Version="2020.3.915" />
     <PackageReference Include="Telerik.Documents.Fixed" Version="2020.3.915" />
     <PackageReference Include="Telerik.Documents.Flow.FormatProviders.Pdf" Version="2020.3.915" />

--- a/src/PdfProcessingAzureFunc/PdfProcessingAzureFunc.csproj
+++ b/src/PdfProcessingAzureFunc/PdfProcessingAzureFunc.csproj
@@ -11,12 +11,12 @@
      For example, Include="Telerik.Documents.Core.Trial" instead of Include="Telerik.Documents.Core" 
     -->
     <PackageReference Include="Microsoft.NET.Sdk.Functions" Version="4.1.0" />
-    <PackageReference Include="Telerik.Documents.Core" Version="2020.3.915" />
-    <PackageReference Include="Telerik.Documents.Fixed" Version="2020.3.915" />
-    <PackageReference Include="Telerik.Documents.Flow.FormatProviders.Pdf" Version="2020.3.915" />
-    <PackageReference Include="Telerik.Documents.Spreadsheet.FormatProviders.OpenXml" Version="2020.3.915" />
-    <PackageReference Include="Telerik.Documents.Spreadsheet.FormatProviders.Pdf" Version="2020.3.915" />
-    <PackageReference Include="Telerik.Documents.Spreadsheet" Version="2020.3.915" />
+    <PackageReference Include="Telerik.Documents.Core" Version="2022.1.217" />
+    <PackageReference Include="Telerik.Documents.Fixed" Version="2022.1.217" />
+    <PackageReference Include="Telerik.Documents.Flow.FormatProviders.Pdf" Version="2022.1.217" />
+    <PackageReference Include="Telerik.Documents.Spreadsheet.FormatProviders.OpenXml" Version="2022.1.217" />
+    <PackageReference Include="Telerik.Documents.Spreadsheet.FormatProviders.Pdf" Version="2022.1.217" />
+    <PackageReference Include="Telerik.Documents.Spreadsheet" Version="2022.1.217" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/src/PdfProcessingAzureFunc/PdfProcessingFunction.cs
+++ b/src/PdfProcessingAzureFunc/PdfProcessingFunction.cs
@@ -1,14 +1,12 @@
-using System;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Extensions.Logging;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
-using System.Web.Http;
-using Microsoft.AspNetCore.Mvc;
-using Microsoft.Azure.WebJobs;
-using Microsoft.Azure.WebJobs.Extensions.Http;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Logging;
 using Telerik.Windows.Documents.Fixed.FormatProviders.Pdf.Export;
 using Telerik.Windows.Documents.Fixed.FormatProviders.Pdf.Streaming;
 
@@ -50,17 +48,11 @@ namespace PdfProcessingAzureFunc
             // Load the original file (NOTE: In this test, we're using a single test PDF download from public azure blob)
             byte[] sourcePdfBytes = null;
 
-            using (var client = new HttpClient())
-            {
-                sourcePdfBytes = await client.GetByteArrayAsync("https://progressdevsupport.blob.core.windows.net/sampledocs/BarChart.pdf");
-                log.LogInformation($"Source File Downloaded...");
-            }
+            using var client = new HttpClient();
 
-            if (sourcePdfBytes == null)
-            {
-                return new ExceptionResult(new Exception("Original file source could not be downloaded"), true);
-            }
-
+            sourcePdfBytes = await client.GetByteArrayAsync("https://progressdevsupport.blob.core.windows.net/sampledocs/BarChart.pdf");
+            log.LogInformation($"Source File Downloaded...");
+            
             // Because HttpClient result stream is not seekable, I switch to using the byte[] and a new MemoryStream for the Telerik PdfFileSource
             await using var sourcePdfStream = new MemoryStream(sourcePdfBytes);
 

--- a/src/PdfProcessingAzureFunc/SpreadProcessingFunction.cs
+++ b/src/PdfProcessingAzureFunc/SpreadProcessingFunction.cs
@@ -1,11 +1,11 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Extensions.Logging;
 using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
-using Microsoft.Azure.WebJobs;
-using Microsoft.Azure.WebJobs.Extensions.Http;
-using Microsoft.AspNetCore.Http;
-using Microsoft.Extensions.Logging;
 using Telerik.Windows.Documents.Spreadsheet.Model;
 
 namespace PdfProcessingAzureFunc
@@ -18,10 +18,10 @@ namespace PdfProcessingAzureFunc
             ILogger log)
         {
             // Step 1. Mocking an uploaded XLSX file (you would normally use req.Body for this)
-            Workbook workbook = new Workbook();
-            Worksheet worksheet = workbook.Worksheets.Add();
+            var workbook = new Workbook();
+            var worksheet = workbook.Worksheets.Add();
 
-            CellSelection selection = worksheet.Cells[0, 1]; // B0
+            var selection = worksheet.Cells[0, 1]; // B0
             selection.SetValue("Azure Function - XLSX to PDF Converter");
 
             selection = worksheet.Cells[1, 1]; // B2
@@ -44,7 +44,7 @@ namespace PdfProcessingAzureFunc
 
             if (memoryStream.Position != 0) memoryStream.Position = 0;
 
-            HttpResponseMessage response = new HttpResponseMessage(HttpStatusCode.OK)
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
             {
                 //Set the PDF document content response
                 Content = new ByteArrayContent(memoryStream.ToArray())

--- a/src/global.json
+++ b/src/global.json
@@ -1,6 +1,6 @@
 {
     "sdk": {
-        "version": "3.1.302",
+        "version": "6.0.1",
         "rollForward": "latestFeature"
     }
 }


### PR DESCRIPTION
Microsoft will be removing Azure Functions support for .NET Core 3.1. See https://azure.microsoft.com/en-us/updates/extended-support-for-microsoft-net-core-31-will-end-on-3-december-2022/

This PR has all the required .NET 6 updates, as well as some small housekeeping improvements.